### PR TITLE
Feature/extend user profile

### DIFF
--- a/src/main/java/com/uguimar/authms/application/service/RegisterUserService.java
+++ b/src/main/java/com/uguimar/authms/application/service/RegisterUserService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
 import java.util.Set;
 
 @Service
@@ -31,7 +32,14 @@ public class RegisterUserService implements RegisterUserUseCase {
                     user.setPassword(passwordEncoder.encode(user.getPassword()));
                     user.setEnabled(true);
 
-                    // Asignar rol de usuario por defecto si no tiene roles
+                    // Set audit fields for new registrations
+                    Instant now = Instant.now();
+                    user.setCreatedBy("self-registration");
+                    user.setCreatedDate(now);
+                    user.setLastModifiedBy("self-registration");
+                    user.setLastModifiedDate(now);
+
+                    // Assign default user role if not set
                     if (user.getRoles() == null || user.getRoles().isEmpty()) {
                         Role userRole = Role.builder().name("USER").build();
                         user.setRoles(Set.of(userRole));

--- a/src/main/java/com/uguimar/authms/domain/model/Auditable.java
+++ b/src/main/java/com/uguimar/authms/domain/model/Auditable.java
@@ -1,0 +1,13 @@
+package com.uguimar.authms.domain.model;
+
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+public abstract class Auditable {
+    private String createdBy;
+    private Instant createdDate;
+    private String lastModifiedBy;
+    private Instant lastModifiedDate;
+}

--- a/src/main/java/com/uguimar/authms/domain/model/User.java
+++ b/src/main/java/com/uguimar/authms/domain/model/User.java
@@ -4,19 +4,24 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User extends Auditable {
     private String id;
     private String username;
     private String email;
     private String password;
+    private String firstName;
+    private String lastName;
+    private LocalDate birthDate;
     @Builder.Default
     private Set<Role> roles = new HashSet<>();
     private boolean enabled;

--- a/src/main/java/com/uguimar/authms/infrastructure/config/AuditingConfig.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/config/AuditingConfig.java
@@ -1,0 +1,24 @@
+package com.uguimar.authms.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.ReactiveAuditorAware;
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import reactor.core.publisher.Mono;
+
+@Configuration
+@EnableR2dbcAuditing
+public class AuditingConfig {
+
+    @Bean
+    ReactiveAuditorAware<String> auditorAware() {
+        return () -> ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getName)
+                .switchIfEmpty(Mono.just("system"));
+    }
+}

--- a/src/main/java/com/uguimar/authms/infrastructure/input/rest/dto/RegisterResponse.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/input/rest/dto/RegisterResponse.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+import java.time.LocalDate;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -13,5 +16,11 @@ public class RegisterResponse {
     private String id;
     private String username;
     private String email;
+    private String firstName;
+    private String lastName;
+    private LocalDate birthDate;
     private String message;
+    // Audit fields
+    private String createdBy;
+    private Instant createdDate;
 }

--- a/src/main/java/com/uguimar/authms/infrastructure/input/rest/mapper/AuthMapper.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/input/rest/mapper/AuthMapper.java
@@ -23,7 +23,12 @@ public class AuthMapper {
                 .id(user.getId())
                 .username(user.getUsername())
                 .email(user.getEmail())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .birthDate(user.getBirthDate())
                 .message("Usuario registrado exitosamente")
+                .createdBy(user.getCreatedBy())
+                .createdDate(user.getCreatedDate())
                 .build();
     }
 

--- a/src/main/java/com/uguimar/authms/infrastructure/output/persistence/R2dbcUserRepository.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/output/persistence/R2dbcUserRepository.java
@@ -134,23 +134,45 @@ public class R2dbcUserRepository implements UserRepository {
                 .collect(Collectors.toSet())
                 : new HashSet<>();
 
-        return User.builder()
+        User user = User.builder()
                 .id(entity.getId())
                 .username(entity.getUsername())
                 .email(entity.getEmail())
                 .password(entity.getPassword())
+                .firstName(entity.getFirstName())
+                .lastName(entity.getLastName())
+                .birthDate(entity.getBirthDate())
                 .roles(roles)
                 .enabled(entity.isEnabled())
                 .build();
+
+        // Set audit fields
+        user.setCreatedBy(entity.getCreatedBy());
+        user.setCreatedDate(entity.getCreatedDate());
+        user.setLastModifiedBy(entity.getLastModifiedBy());
+        user.setLastModifiedDate(entity.getLastModifiedDate());
+
+        return user;
     }
 
     private UserEntity mapToEntity(User domain) {
-        return UserEntity.builder()
+        UserEntity entity = UserEntity.builder()
                 .id(domain.getId())
                 .username(domain.getUsername())
                 .email(domain.getEmail())
                 .password(domain.getPassword())
+                .firstName(domain.getFirstName())
+                .lastName(domain.getLastName())
+                .birthDate(domain.getBirthDate())
                 .enabled(domain.isEnabled())
                 .build();
+
+        // Set audit fields from domain if available (for updates)
+        entity.setCreatedBy(domain.getCreatedBy());
+        entity.setCreatedDate(domain.getCreatedDate());
+        entity.setLastModifiedBy(domain.getLastModifiedBy());
+        entity.setLastModifiedDate(domain.getLastModifiedDate());
+
+        return entity;
     }
 }

--- a/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/AuditableEntity.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/AuditableEntity.java
@@ -1,0 +1,35 @@
+package com.uguimar.authms.infrastructure.output.persistence.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Column;
+
+import java.time.Instant;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditableEntity {
+    @CreatedBy
+    @Column("created_by")
+    private String createdBy;
+
+    @CreatedDate
+    @Column("created_date")
+    private Instant createdDate;
+
+    @LastModifiedBy
+    @Column("last_modified_by")
+    private String lastModifiedBy;
+
+    @LastModifiedDate
+    @Column("last_modified_date")
+    private Instant lastModifiedDate;
+}

--- a/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/UserEntity.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/UserEntity.java
@@ -35,6 +35,18 @@ public class UserEntity implements Persistable<String> {
     @Column("enabled")
     private boolean enabled;
 
+    @Column("first_name")
+    private String firstName;
+
+    @Column("last_name")
+    private String lastName;
+
+    @Column("age")
+    private Integer age;
+
+    @Column("photo_url")
+    private String photoUrl;
+
     @Transient
     private Set<RoleEntity> roles;
 

--- a/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/UserEntity.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/UserEntity.java
@@ -35,18 +35,6 @@ public class UserEntity implements Persistable<String> {
     @Column("enabled")
     private boolean enabled;
 
-    @Column("first_name")
-    private String firstName;
-
-    @Column("last_name")
-    private String lastName;
-
-    @Column("age")
-    private Integer age;
-
-    @Column("photo_url")
-    private String photoUrl;
-
     @Transient
     private Set<RoleEntity> roles;
 

--- a/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/UserEntity.java
+++ b/src/main/java/com/uguimar/authms/infrastructure/output/persistence/entity/UserEntity.java
@@ -4,21 +4,23 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.time.LocalDate;
 import java.util.Set;
 import java.util.UUID;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table("users")
-public class UserEntity implements Persistable<String> {
+public class UserEntity extends AuditableEntity implements Persistable<String> {
 
     @Id
     private String id;
@@ -31,6 +33,15 @@ public class UserEntity implements Persistable<String> {
 
     @Column("password")
     private String password;
+
+    @Column("first_name")
+    private String firstName;
+
+    @Column("last_name")
+    private String lastName;
+
+    @Column("birth_date")
+    private LocalDate birthDate;
 
     @Column("enabled")
     private boolean enabled;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,7 +4,11 @@ CREATE TABLE IF NOT EXISTS users
     username VARCHAR(50) UNIQUE  NOT NULL,
     email    VARCHAR(100) UNIQUE NOT NULL,
     password VARCHAR(100)        NOT NULL,
-    enabled  BOOLEAN DEFAULT TRUE
+    enabled  BOOLEAN DEFAULT TRUE,
+    first_name VARCHAR(100) NULL,
+    last_name  VARCHAR(100) NULL,
+    age        SMALLINT NULL,
+    photo_url VARCHAR(255) NULL
 );
 
 CREATE TABLE IF NOT EXISTS roles

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -4,11 +4,7 @@ CREATE TABLE IF NOT EXISTS users
     username VARCHAR(50) UNIQUE  NOT NULL,
     email    VARCHAR(100) UNIQUE NOT NULL,
     password VARCHAR(100)        NOT NULL,
-    enabled  BOOLEAN DEFAULT TRUE,
-    first_name VARCHAR(100) NULL,
-    last_name  VARCHAR(100) NULL,
-    age        SMALLINT NULL,
-    photo_url VARCHAR(255) NULL
+    enabled  BOOLEAN DEFAULT TRUE
 );
 
 CREATE TABLE IF NOT EXISTS roles

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,10 +1,17 @@
 CREATE TABLE IF NOT EXISTS users
 (
-    id       VARCHAR(36) PRIMARY KEY,
-    username VARCHAR(50) UNIQUE  NOT NULL,
-    email    VARCHAR(100) UNIQUE NOT NULL,
-    password VARCHAR(100)        NOT NULL,
-    enabled  BOOLEAN DEFAULT TRUE
+    id                 VARCHAR(36) PRIMARY KEY,
+    username           VARCHAR(50) UNIQUE  NOT NULL,
+    email              VARCHAR(100) UNIQUE NOT NULL,
+    password           VARCHAR(100)        NOT NULL,
+    first_name         VARCHAR(100)        NOT NULL,
+    last_name          VARCHAR(100)        NOT NULL,
+    birth_date         DATE                NOT NULL,
+    enabled            BOOLEAN     DEFAULT TRUE,
+    created_by         VARCHAR(100)        NOT NULL,
+    created_date       TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    last_modified_by   VARCHAR(100)        NOT NULL,
+    last_modified_date TIMESTAMPTZ
 );
 
 CREATE TABLE IF NOT EXISTS roles


### PR DESCRIPTION
## ✅ Tareas

- [x] Modificar `UserEntity.java` para incluir los siguientes campos:
  - `firstName: String`
  - `lastName: String`
  - `age: Integer`
  - `photoUrl: String`

- [x] Actualizar el esquema de la base de datos (`schema.sql`) para agregar las nuevas columnas:
  - `enabled BOOLEAN DEFAULT TRUE`
  - `first_name VARCHAR(100) NULL`
  - `last_name VARCHAR(100) NULL`
  - `age SMALLINT NULL`
  - `photo_url VARCHAR(255) NULL`

- [x] Verificar compatibilidad con el endpoint de registro:
  - Se comprobó que el endpoint `/register` sigue funcionando correctamente al crear usuarios con `username`, `email`, y `password`, dejando los nuevos campos como `NULL` para ser completados posteriormente.